### PR TITLE
Prepare Release v2.2.2

### DIFF
--- a/includes/Admin/views/list-category-showcase.php
+++ b/includes/Admin/views/list-category-showcase.php
@@ -21,7 +21,7 @@ $list_table->prepare_items();
 			<?php esc_html_e( 'Add New', 'wc-category-showcase' ); ?>
 		</a>
 	</h1>
-	<p><?php esc_html_e( 'Bellow are the all category showcases.', 'wc-category-showcase' ); ?></p>
+
 	<hr class="wp-header-end">
 
 	<form id="wc-category-showcase-table" method="get">

--- a/languages/wc-category-showcase.pot
+++ b/languages/wc-category-showcase.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Category Showcase 2.2.1\n"
+"Project-Id-Version: WC Category Showcase 2.2.2\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-05-19 06:30:03+00:00\n"
+"POT-Creation-Date: 2025-07-03 06:23:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -339,10 +339,6 @@ msgstr ""
 #: includes/Admin/views/list-category-showcase.php:19
 #: includes/Admin/views/showcase/showcase-settings.php:589
 msgid "Category Showcase"
-msgstr ""
-
-#: includes/Admin/views/list-category-showcase.php:24
-msgid "Bellow are the all category showcases."
 msgstr ""
 
 #: includes/Admin/views/list-category-showcase.php:32

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-category-showcase",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-category-showcase",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "tailwindcss-inner-border": "^0.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wc-category-showcase",
   "title": "WooCommerce Category Showcase",
   "description": "WooCommerce extension to showcase categories in various styles and layouts like sliders, blocks, and grids.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "homepage": "https://pluginever.com/plugins/woocommerce-category-showcase-pro/",
   "author": {
     "name": "PluginEver",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, woocommerce Category, woocommerce Category Slider, WooCommerc
 Requires at least: 5.2
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,10 @@ Place the snippet where you want. Change the id with the appropriate one.
 4. Example showcase
 
 == Changelog ==
+= 2.2.2 (3rd July 2025) =
+* Fix - Resolved few known issues.
+* Compatibility - Compatible with the latest version of WordPress and WooCommerce.
+
 = 2.2.1 (19th May 2025) =
 * Fix - Image not zooming on hover.
 * Security - Fixed security issues.

--- a/wc-category-showcase.php
+++ b/wc-category-showcase.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Category Showcase
  * Plugin URI:           https://pluginever.com/plugins/woocommerce-category-showcase-pro/
  * Description:          WooCommerce extension to showcase categories in various styles and layouts like sliders, blocks, and grids.
- * Version:              2.2.1
+ * Version:              2.2.2
  * Author:               PluginEver
  * Author URI:           https://pluginever.com
  * License:              GPL v2 or later
@@ -14,7 +14,7 @@
  * Tested up to:         6.8
  * Requires PHP:         7.4
  * WC requires at least: 3.0.0
- * WC tested up to:      9.8
+ * WC tested up to:      9.9
  * Requires plugin:      woocommerce
  *
  * @package WooCommerceCategoryShowcase


### PR DESCRIPTION
This pull request updates the `WC Category Showcase` plugin to version 2.2.2, addressing known issues, improving compatibility with the latest WordPress and WooCommerce versions, and making minor corrections. Below are the most important changes:

### Version and Compatibility Updates:
* Updated plugin version to `2.2.2` in `package.json`, `readme.txt`, and `wc-category-showcase.php`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[3]](diffhunk://#diff-3fad6be205bacaaebfc4f7bfba391392b6eaeab8c9ee56c8785fb71ea98bcff2L6-R6)
* Updated `WC tested up to` compatibility from version `9.8` to `9.9` in `wc-category-showcase.php`.

### Translation and Text Updates:
* Removed an inaccurate sentence from `list-category-showcase.php` ("Bellow are the all category showcases.") and its corresponding translation entry in `wc-category-showcase.pot`. [[1]](diffhunk://#diff-edd10a602956f9edda8441f4b9456303d7e8826cc4190c5f98c2eb3b39d6a1e3L24-R24) [[2]](diffhunk://#diff-1e581a6ea6a99df667a8e48864c6585ac2d48bf10075c9caa5c971aea2d5d5d3L344-L347)

### Documentation Updates:
* Added a changelog entry for version `2.2.2` in `readme.txt`, highlighting fixes and compatibility improvements.

These changes ensure the plugin remains up-to-date, improves clarity, and resolves existing issues.